### PR TITLE
[fpt] feat: add `--max-exec-time` for `script` command

### DIFF
--- a/cmd/fpt/ChangeLog.md
+++ b/cmd/fpt/ChangeLog.md
@@ -1,3 +1,7 @@
+v1.6.0 / 2022-08-24
+-------------------
+* Added `--max-exec-time` flag to `fpt script` command
+
 v1.5.0 / 2022-04-26
 -------------------
 * Changed expected host pattern for Flexera One Eu to include `api.eu-central-1.policy-eu.flexeraeng.com`

--- a/cmd/fpt/fixtures/maxExecTime.pt
+++ b/cmd/fpt/fixtures/maxExecTime.pt
@@ -1,0 +1,31 @@
+name "Max Execution Time Test Policy"
+rs_pt_ver 20180301
+short_description "Single datasource that sleeps for 60s.  Used to test `fpt script --max-exec-time` feature"
+category "testing"
+
+
+datasource "ds_sleep" do
+  run_script $js_sleep
+end
+
+script "js_sleep", type: "javascript" do
+  result "result"
+  code <<-EOS
+var sleep_duration = 60 * 1000; // 1 minute in ms
+var start = new Date();
+while (new Date() - start < sleep_duration) {
+  // do nothing
+}
+var duration = new Date() - start;
+console.log("Slept for " + duration + " ms");
+var result = duration;
+EOS
+end
+
+policy "policy" do
+  validate $ds_sleep do
+    summary_template "Slept for {{ data }} ms"
+    detail_template "Slept for {{ data }} ms"
+    check eq(0, 1) # always fail check and create incident
+  end
+end

--- a/cmd/fpt/fixtures/maxExecTime.pt
+++ b/cmd/fpt/fixtures/maxExecTime.pt
@@ -1,6 +1,6 @@
 name "Max Execution Time Test Policy"
 rs_pt_ver 20180301
-short_description "Single datasource that sleeps for 60s.  Used to test `fpt script --max-exec-time` feature"
+short_description "Single datasource that sleeps for 10s.  Used to test `fpt script --max-exec-time` feature"
 category "testing"
 
 
@@ -11,7 +11,7 @@ end
 script "js_sleep", type: "javascript" do
   result "result"
   code <<-EOS
-var sleep_duration = 60 * 1000; // 1 minute in ms
+var sleep_duration = 10 * 1000; // 10 seconds in ms
 var start = new Date();
 while (new Date() - start < sleep_duration) {
   // do nothing

--- a/cmd/fpt/main.go
+++ b/cmd/fpt/main.go
@@ -62,11 +62,12 @@ Example: fpt retrieve_data my_policy.pt --names instances
 
 Example: fpt script max_snapshots.pt volumes=@ec2_volumes.json max_count=50 exclude_names=["foo","bar","baz"]
 `)
-	scriptFile    = scriptCmd.Arg("file", "File may be a Policy Template or a raw JavaScript.").Required().ExistingFile()
-	scriptOptions = scriptCmd.Arg("parameters", `Script parameters must be in the form of "<name>=<value>". To specify a file as input such as a datasource retrieved via the retrieve_data command, specify @<filename> as the value. For list parameters, a JSON encoded array may be passed as the value.`).Strings()
-	scriptOut     = scriptCmd.Flag("out", "Script output file. Defaults to out.json").Short('o').Default("out.json").String()
-	scriptResult  = scriptCmd.Flag("result", "Name of variable holding final result to extract. Required if supplying a raw JavaScript.").Short('r').String()
-	scriptName    = scriptCmd.Flag("name", "Name of script to run, if multiple exist.").Short('n').String()
+	scriptFile        = scriptCmd.Arg("file", "File may be a Policy Template or a raw JavaScript.").Required().ExistingFile()
+	scriptOptions     = scriptCmd.Arg("parameters", `Script parameters must be in the form of "<name>=<value>". To specify a file as input such as a datasource retrieved via the retrieve_data command, specify @<filename> as the value. For list parameters, a JSON encoded array may be passed as the value.`).Strings()
+	scriptOut         = scriptCmd.Flag("out", "Script output file. Defaults to out.json").Short('o').Default("out.json").String()
+	scriptResult      = scriptCmd.Flag("result", "Name of variable holding final result to extract. Required if supplying a raw JavaScript.").Short('r').String()
+	scriptName        = scriptCmd.Flag("name", "Name of script to run, if multiple exist.").Short('n').String()
+	scriptMaxExecTime = scriptCmd.Flag("max-exec-time", "Maximum time (in seconds) to allow script to run.").Default("600").Int()
 
 	// ----- Configuration -----
 	configCmd = app.Command("config", "Manage Configuration")
@@ -154,7 +155,7 @@ func main() {
 			fatalError("%s\n", err.Error())
 		}
 	case scriptCmd.FullCommand():
-		err = runScript(ctx, *scriptFile, *scriptOut, *scriptResult, *scriptName, *scriptOptions)
+		err = runScript(ctx, *scriptFile, *scriptOut, *scriptResult, *scriptName, *scriptMaxExecTime, *scriptOptions)
 		if err != nil {
 			fatalError("%s\n", err.Error())
 		}

--- a/cmd/fpt/script_test.go
+++ b/cmd/fpt/script_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"io/ioutil"
 	"os"
 	"reflect"
@@ -8,6 +9,31 @@ import (
 
 	"github.com/robertkrimen/otto/parser"
 )
+
+var (
+	ctx = context.Background()
+	err error
+
+	maxExecTimeTestTemplateFile = "fixtures/maxExecTime.pt"
+)
+
+func TestScriptMaxRunTimeError(t *testing.T) {
+	// Test with maxExecTime=1 which is < 10s script runtime
+	// Expect an error
+	err = runScript(ctx, maxExecTimeTestTemplateFile, "out.json", "", maxExecTimeTestTemplateFile, 1, []string{})
+	if err == nil {
+		t.Error("Expected error when maxExecTime=1, got nil")
+	}
+}
+
+func TestScriptMaxRunTimeSucess(t *testing.T) {
+	// Test with maxExecTime=20 which is > 10s script runtime
+	// Expect no error
+	err = runScript(ctx, maxExecTimeTestTemplateFile, "out.json", "", maxExecTimeTestTemplateFile, 20, []string{})
+	if err != nil {
+		t.Error(err)
+	}
+}
 
 func TestScriptErrorListError(t *testing.T) {
 	var (


### PR DESCRIPTION
Adds `--max-execution-time` flag to `fpt script` command which can be used to modify the javascript execution time limit.

```sh
$ ./fpt --version
fpt dev - 2022-08-22 21:50:46 - c0fcd4b8d460142a43e55b78ffbe05b33de9c706
```
1 sec timeout
```sh
$ time ./fpt script cmd/fpt/fixtures/maxExecTime.pt --max-exec-time 1
Running script "js_sleep" from cmd/fpt/fixtures/maxExecTime.pt and writing result to out.json
ERROR: script execution exceeded 1s
real    0m1.645s
user    0m1.256s
sys     0m0.079s
```

10 sec timeout
```sh
$ time ./fpt script cmd/fpt/fixtures/maxExecTime.pt --max-exec-time 10
Running script "js_sleep" from cmd/fpt/fixtures/maxExecTime.pt and writing result to out.json
ERROR: script execution exceeded 10s
real    0m10.609s
user    0m12.141s
sys     0m0.416s
```

default (600s) success:
```sh
$ time ./fpt script cmd/fpt/fixtures/maxExecTime.pt 
Running script "js_sleep" from cmd/fpt/fixtures/maxExecTime.pt and writing result to out.json
console.log: "Slept for 60000 ms"
JavaScript finished, duration=59.999940842s
real    1m1.015s
user    1m13.091s
sys     0m2.196s
```