### PR TITLE
feat: fpt enhancements

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,25 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the
+// README at: https://github.com/devcontainers/templates/tree/main/src/go
+{
+	"name": "Go",
+	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
+	"image": "mcr.microsoft.com/devcontainers/go:1-1.24-bookworm",
+	"features": {
+		"ghcr.io/devcontainers/features/git-lfs:1": {}
+	}
+
+	// Features to add to the dev container. More info: https://containers.dev/features.
+	// "features": {},
+
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	// "forwardPorts": [],
+
+	// Use 'postCreateCommand' to run commands after the container is created.
+	// "postCreateCommand": "go version",
+
+	// Configure tool-specific properties.
+	// "customizations": {},
+
+	// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
+	// "remoteUser": "root"
+}

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for more information:
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+# https://containers.dev/guide/dependabot
+
+version: 2
+updates:
+ - package-ecosystem: "devcontainers"
+   directory: "/"
+   schedule:
+     interval: weekly

--- a/cmd/fpt/main.go
+++ b/cmd/fpt/main.go
@@ -56,18 +56,20 @@ Example: fpt retrieve_data my_policy.pt --names instances
 	rdCredentials = rdCmd.Flag("credentials", `Credentials is the map of name and credential used to launch the policy. Credentials must be of the form "--credentials <name1>=<value1> --credentials <name2>=<value2>".`).Short('C').Strings()
 	rdNames       = rdCmd.Flag("names", "Names of resources/datasources to retrieve. By default, all datasources will be retrieved.").Short('n').Strings()
 	rdOD          = rdCmd.Flag("output-dir", "Directory to store retrieved datasources.").Short('o').String()
+	rdMetaFix     = rdCmd.Flag("disable-meta-fix", "Disable meta fix during data retrieval which can prevent error with Meta enabled child policy templates.").Bool()
 
 	// ----- Run Script -----
 	scriptCmd = app.Command("script", `Run the body of a script locally.
 
 Example: fpt script max_snapshots.pt volumes=@ec2_volumes.json max_count=50 exclude_names=["foo","bar","baz"]
 `)
-	scriptFile        = scriptCmd.Arg("file", "File may be a Policy Template or a raw JavaScript.").Required().ExistingFile()
-	scriptOptions     = scriptCmd.Arg("parameters", `Script parameters must be in the form of "<name>=<value>". To specify a file as input such as a datasource retrieved via the retrieve_data command, specify @<filename> as the value. For list parameters, a JSON encoded array may be passed as the value.`).Strings()
-	scriptOut         = scriptCmd.Flag("out", "Script output file. Defaults to out.json").Short('o').Default("out.json").String()
-	scriptResult      = scriptCmd.Flag("result", "Name of variable holding final result to extract. Required if supplying a raw JavaScript.").Short('r').String()
-	scriptName        = scriptCmd.Flag("name", "Name of script to run, if multiple exist.").Short('n').String()
-	scriptMaxExecTime = scriptCmd.Flag("max-exec-time", "Maximum time (in seconds) to allow script to run.").Default("600").Int()
+	scriptFile                        = scriptCmd.Arg("file", "File may be a Policy Template or a raw JavaScript.").Required().ExistingFile()
+	scriptOptions                     = scriptCmd.Arg("parameters", `Script parameters must be in the form of "<name>=<value>". To specify a file as input such as a datasource retrieved via the retrieve_data command, specify @<filename> as the value. For list parameters, a JSON encoded array may be passed as the value.`).Strings()
+	scriptOut                         = scriptCmd.Flag("out", "Script output file. Defaults to out.json").Short('o').Default("out.json").String()
+	scriptResult                      = scriptCmd.Flag("result", "Name of variable holding final result to extract. Required if supplying a raw JavaScript.").Short('r').String()
+	scriptName                        = scriptCmd.Flag("name", "Name of script to run, if multiple exist.").Short('n').String()
+	scriptMaxExecTime                 = scriptCmd.Flag("max-exec-time", "Maximum time (in seconds) to allow script to run.").Default("600").Int()
+	scriptDisableAssumeDatasourceJSON = scriptCmd.Flag("disable-assume-datasource-json", "Disable automatic detection and use of datasource_{datasourcename}.json files for script parameters.").Bool()
 
 	// ----- Configuration -----
 	configCmd = app.Command("config", "Manage Configuration")
@@ -125,6 +127,11 @@ func main() {
 		defer UpdateCheck(VV, os.Stderr)
 	}
 
+	// Enable Meta-Fix capability on client if requested
+	if rdMetaFix != nil && *rdMetaFix {
+		client.EnableMetaFixDuringRetrieveData()
+	}
+
 	switch command {
 	case upCmd.FullCommand():
 		files, err := walkPaths(*upFiles)
@@ -155,7 +162,7 @@ func main() {
 			fatalError("%s\n", err.Error())
 		}
 	case scriptCmd.FullCommand():
-		err = runScript(ctx, *scriptFile, *scriptOut, *scriptResult, *scriptName, *scriptMaxExecTime, *scriptOptions)
+		err = runScript(ctx, *scriptFile, *scriptOut, *scriptResult, *scriptName, *scriptMaxExecTime, *scriptOptions, !*scriptDisableAssumeDatasourceJSON)
 		if err != nil {
 			fatalError("%s\n", err.Error())
 		}

--- a/cmd/fpt/retrieve_data.go
+++ b/cmd/fpt/retrieve_data.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/rightscale/policy_sdk/client/policy"
 	appliedpolicy "github.com/rightscale/policy_sdk/sdk/applied_policy"
@@ -35,6 +36,17 @@ func policyTemplateRetrieveData(ctx context.Context, cli policy.Client, file str
 	fmt.Printf("Retrieving Data from PolicyTemplate (%s)\n", pt.Href)
 	rd, err := cli.RetrieveData(ctx, pt.ID, names, options, credentials)
 	if err != nil {
+		// Instead of returning "not_found" error, return a more descriptive error message
+		// "not_found" is usually due to an issue with the credential ID(s) specified
+		if err.Error() == "not_found" {
+			// Get list of values from credentials map
+			var creds []string
+			for k := range credentials {
+				creds = append(creds, k)
+			}
+			// Update error message
+			err = fmt.Errorf("At least one credential identifier not found -- please check the credential ID(s) specified. " + strings.Join(creds, ", "))
+		}
 		return err
 	}
 	for _, d := range rd {

--- a/cmd/fpt/retrieve_data.go
+++ b/cmd/fpt/retrieve_data.go
@@ -13,6 +13,8 @@ import (
 )
 
 func policyTemplateRetrieveData(ctx context.Context, cli policy.Client, file string, runOptions, runCredentials, names []string, outputD string) error {
+
+	// If string header "Meta-Flexera", val($ds_flexera_api_hosts, "path") exists, add '# ' to comment it out
 	pt, err := doUpload(ctx, cli, file)
 	if err != nil {
 		return err

--- a/config/config.go
+++ b/config/config.go
@@ -30,7 +30,7 @@ type (
 var (
 	Config        ConfigViper
 	boolRegexp    = regexp.MustCompile(`^(?i:true)$`)
-	hostRegexp    = regexp.MustCompile(`^(?:governance-(\d+)\.(test\.)?rightscale\.com|eu-central-1\.policy-eu\.flexeraeng\.com|api\.eu-central-1\.policy-eu\.flexeraeng\.com)$`)
+	hostRegexp    = regexp.MustCompile(`^(?:governance-(\d+)\.(test\.)?rightscale\.com|eu-central-1\.policy-eu\.flexeraeng\.com|api\.eu-central-1\.policy-eu\.flexeraeng\.com|ap-southeast-2\.policy-apac\.flexeraeng\.com|api\.ap-southeast-2\.policy-apac\.flexeraeng\.com)$`)
 	hostRegexpDep = regexp.MustCompile(`^(?:eu-central-1\.policy-eu\.flexeraeng\.com)$`)
 )
 

--- a/config/config.go
+++ b/config/config.go
@@ -30,7 +30,7 @@ type (
 var (
 	Config        ConfigViper
 	boolRegexp    = regexp.MustCompile(`^(?i:true)$`)
-	hostRegexp    = regexp.MustCompile(`^(?:governance-(\d+)\.(test\.)?rightscale\.com|eu-central-1\.policy-eu\.flexeraeng\.com|api\.eu-central-1\.policy-eu\.flexeraeng\.com|ap-southeast-2\.policy-apac\.flexeraeng\.com|api\.ap-southeast-2\.policy-apac\.flexeraeng\.com)$`)
+	hostRegexp    = regexp.MustCompile(`^(?:governance-(\d+)\.(test\.)?rightscale\.com|eu-central-1\.policy-eu\.flexeraeng\.com|api\.eu-central-1\.policy-eu\.flexeraeng\.com|api\.ap-southeast-2\.policy-apac\.flexeraeng\.com)$`)
 	hostRegexpDep = regexp.MustCompile(`^(?:eu-central-1\.policy-eu\.flexeraeng\.com)$`)
 )
 
@@ -257,7 +257,7 @@ func (config *ConfigViper) ShowConfiguration(output io.Writer) error {
 
 func (a *Account) Validate() error {
 	if !hostRegexp.MatchString(a.Host) {
-		return fmt.Errorf("invalid host: must be of form governance-<shard number>.rightscale.com or api.eu-central-1.policy-eu.flexeraeng.com")
+		return fmt.Errorf("invalid host: must be of form governance-3.rightscale.com, governance-4.rightscale.com, api.eu-central-1.policy-eu.flexeraeng.com, or api.ap-southeast-2.policy-apac.flexeraeng.com")
 	}
 	if hostRegexpDep.MatchString(a.Host) {
 		fmt.Fprintln(os.Stderr, "Warning: API endpoint host eu-central-1.policy-eu.flexeraeng.com is deprecated and will be removed soon. Change profile API endpoint host to api.eu-central-1.policy-eu.flexeraeng.com before May 23rd")


### PR DESCRIPTION
This pull request introduces several improvements and new features to the CLI and client library, focusing on enhanced usability, better error messaging, and support for additional environments. The most significant updates include options for automatic datasource parameter detection in scripts, a new capability to apply a "meta fix" during data retrieval, improved error messages for credential issues, and expanded host validation. Additionally, development environment configuration files have been added.

**Enhancements to CLI usability and error handling:**

* Added a `--disable-assume-datasource-json` flag to the `script` command, with logic to automatically detect and use `datasource_{name}.json` files as script parameters unless disabled. This streamlines running scripts with external datasource files. [[1]](diffhunk://#diff-b29a536bae985675280a97a2dd69326a10b6f188da721fbeba8ca1ddad2783a9R72) [[2]](diffhunk://#diff-f2f2456d9def34e5cde8335c161ffbcb8ff9476cb130446494db0d0277bfe80cL66-R66) [[3]](diffhunk://#diff-f2f2456d9def34e5cde8335c161ffbcb8ff9476cb130446494db0d0277bfe80cR79-R83) [[4]](diffhunk://#diff-f2f2456d9def34e5cde8335c161ffbcb8ff9476cb130446494db0d0277bfe80cR255-R321)
* Improved error messages for "not_found" errors in both `retrieve_data` and `run` commands, clarifying that these are typically due to invalid credential IDs and listing the problematic credentials. [[1]](diffhunk://#diff-2577214582eb429ec50ad3ba66478e716d18ce5129a65c5599b7438b5b759e58R41-R51) [[2]](diffhunk://#diff-fcdc4e10fb265aff20e471062caba50f91434f0aa4531d562e1cf00a24a3ccfaR76-R86)

**Meta fix capability for data retrieval:**

* Introduced a new "meta fix" feature to comment out problematic `header "Meta-Flexera", val($ds_is_deleted, "path")` lines in policy templates during data retrieval, preventing errors with Meta-enabled child templates. This can be toggled with a new flag in the CLI and corresponding methods in the client. [[1]](diffhunk://#diff-77fe7caf93a7138199bbd677601e6b001826161d9f7882d0fa18b635b44e0399R43-R46) [[2]](diffhunk://#diff-77fe7caf93a7138199bbd677601e6b001826161d9f7882d0fa18b635b44e0399R59) [[3]](diffhunk://#diff-77fe7caf93a7138199bbd677601e6b001826161d9f7882d0fa18b635b44e0399R140-R154) [[4]](diffhunk://#diff-b29a536bae985675280a97a2dd69326a10b6f188da721fbeba8ca1ddad2783a9R59) [[5]](diffhunk://#diff-b29a536bae985675280a97a2dd69326a10b6f188da721fbeba8ca1ddad2783a9R130-R134) [[6]](diffhunk://#diff-161215209ae0040dc142dae6341eb59632ea6e91a0e2142ccb0ea43e9dbddb68R39-R57)

**Environment and host configuration:**

* Expanded valid API host patterns and updated validation error messages to support the new APAC region endpoint (`api.ap-southeast-2.policy-apac.flexeraeng.com`). [[1]](diffhunk://#diff-fe44f09c4d5977b5f5eaea29170b6a0748819c9d02271746a20d81a5f3efca17L33-R33) [[2]](diffhunk://#diff-fe44f09c4d5977b5f5eaea29170b6a0748819c9d02271746a20d81a5f3efca17L260-R260)

**Development tooling and automation:**

* Added `.devcontainer/devcontainer.json` for a Go-based development container and `.github/dependabot.yml` for automated dependency updates of devcontainer features. [[1]](diffhunk://#diff-24ad71c8613ddcf6fd23818cb3bb477a1fb6d83af4550b0bad43099813088686R1-R25) [[2]](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28R1-R12)

**Codebase improvements:**

* Minor code cleanups, including import aliasing and improved documentation/comments. [[1]](diffhunk://#diff-77fe7caf93a7138199bbd677601e6b001826161d9f7882d0fa18b635b44e0399L12-R17) [[2]](diffhunk://#diff-77fe7caf93a7138199bbd677601e6b001826161d9f7882d0fa18b635b44e0399R91)

If you have any questions about how to use the new CLI flags or the meta fix feature, let me know!