### PR TITLE
feat: add arm64 binaries to build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,6 +11,9 @@ jobs:
   build-ubuntu:
     name: "Build Binary for Linux"
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        arch: [amd64, arm64]
     defaults:
       run:
         shell: bash
@@ -27,20 +30,23 @@ jobs:
         echo -e "// go:build fpt_make\n\npackage main\n\nconst VV = \"fpt $GITHUB_REF_NAME - $(date '+%F %T') - $GITHUB_SHA\"" > ./cmd/fpt/version.go
         rm -rf build/fpt
         mkdir -p build/fpt
-        go build -tags fpt_make -o build/fpt/fpt ./cmd/fpt
+        GOOS=linux GOARCH=${{ matrix.arch }} go build -tags fpt_make -o build/fpt/fpt ./cmd/fpt
         chmod +x build/fpt/fpt*
-        tar -zcf "fpt-linux-amd64-${GITHUB_REF_NAME}.tgz" -C build fpt
+        tar -zcf "fpt-linux-${{ matrix.arch }}-${GITHUB_REF_NAME}.tgz" -C build fpt
         rm -r build/fpt
 
     - name: Upload Artifact
       uses: actions/upload-artifact@v4
       with:
-        name: fpt-linux-amd64-${{ github.ref_name }}.tgz
-        path: fpt-linux-amd64-${{ github.ref_name }}.tgz
+        name: fpt-linux-${{ matrix.arch }}-${{ github.ref_name }}.tgz
+        path: fpt-linux-${{ matrix.arch }}-${{ github.ref_name }}.tgz
 
   build-macos:
     name: "Build Binary for macOS"
     runs-on: macos-latest
+    strategy:
+      matrix:
+        arch: [amd64, arm64]
     defaults:
       run:
         shell: bash
@@ -57,20 +63,23 @@ jobs:
         echo -e "// go:build fpt_make\n\npackage main\n\nconst VV = \"fpt $GITHUB_REF_NAME - $(date '+%F %T') - $GITHUB_SHA\"" > ./cmd/fpt/version.go
         rm -rf build/fpt
         mkdir -p build/fpt
-        go build -tags fpt_make -o build/fpt/fpt ./cmd/fpt
+        GOOS=darwin GOARCH=${{ matrix.arch }} go build -tags fpt_make -o build/fpt/fpt ./cmd/fpt
         chmod +x build/fpt/fpt*
-        tar -zcf fpt-darwin-amd64-${GITHUB_REF_NAME}.tgz -C build fpt
+        tar -zcf fpt-darwin-${{ matrix.arch }}-${GITHUB_REF_NAME}.tgz -C build fpt
         rm -r build/fpt
 
     - name: Upload Artifact
       uses: actions/upload-artifact@v4
       with:
-        name: fpt-darwin-amd64-${{ github.ref_name }}.tgz
-        path: fpt-darwin-amd64-${{ github.ref_name }}.tgz
+        name: fpt-darwin-${{ matrix.arch }}-${{ github.ref_name }}.tgz
+        path: fpt-darwin-${{ matrix.arch }}-${{ github.ref_name }}.tgz
 
   build-windows:
     name: "Build Binary for Windows"
     runs-on: windows-latest
+    strategy:
+      matrix:
+        arch: [amd64, arm64]
     defaults:
       run:
         shell: bash
@@ -86,19 +95,17 @@ jobs:
       run: |
         echo -e "// go:build fpt_make\n\npackage main\n\nconst VV = \"fpt $GITHUB_REF_NAME - $(date '+%F %T') - $GITHUB_SHA\"" > ./cmd/fpt/version.go
         rm -rf build/fpt
-        export CC="x86_64-w64-mingw32-gcc"
-        export CXX="x86_64-w64-mingw32-g++"
         mkdir -p build/fpt
-        go build -tags fpt_make -o build/fpt/fpt.exe ./cmd/fpt
+        GOOS=windows GOARCH=${{ matrix.arch }} go build -tags fpt_make -o build/fpt/fpt.exe ./cmd/fpt
         chmod +x build/fpt/fpt.exe
-        pushd build; ls; pwd; 7z a -r ../fpt-windows-amd64-${GITHUB_REF_NAME}.zip fpt; ls; pwd; popd
+        pushd build; ls; pwd; 7z a -r ../fpt-windows-${{ matrix.arch }}-${GITHUB_REF_NAME}.zip fpt; ls; pwd; popd
         rm -r build/fpt
     
     - name: Upload Artifact
       uses: actions/upload-artifact@v4
       with:
-        name: fpt-windows-amd64-${{ github.ref_name }}.zip
-        path: fpt-windows-amd64-${{ github.ref_name }}.zip
+        name: fpt-windows-${{ matrix.arch }}-${{ github.ref_name }}.zip
+        path: fpt-windows-${{ matrix.arch }}-${{ github.ref_name }}.zip
 
   release:
     if: startsWith(github.ref, 'refs/tags/v') # Only upload on tag push events
@@ -122,5 +129,8 @@ jobs:
         # actions/download-artifact uses folders to store artifacts, so we need to include the wildcard to get the actual files
         files: |
           fpt-linux-amd64-${{ github.ref_name }}.tgz/*
+          fpt-linux-arm64-${{ github.ref_name }}.tgz/*
           fpt-darwin-amd64-${{ github.ref_name }}.tgz/*
+          fpt-darwin-arm64-${{ github.ref_name }}.tgz/*
           fpt-windows-amd64-${{ github.ref_name }}.zip/*
+          fpt-windows-arm64-${{ github.ref_name }}.zip/*


### PR DESCRIPTION
This pull request updates the GitHub Actions build workflow to add support for building and packaging binaries for both amd64 and arm64 architectures across Linux, macOS, and Windows. The changes ensure that release artifacts are generated for both architectures and that naming conventions are updated accordingly.

**Multi-architecture build and packaging support:**

* Added build matrix strategies for `amd64` and `arm64` architectures in the `build-ubuntu`, `build-macos`, and `build-windows` jobs, allowing the workflow to build binaries for both architectures. [[1]](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721R14-R16) [[2]](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721L60-R82) [[3]](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721L89-R108)
* Updated the build commands to use the appropriate `GOARCH` value from the matrix for each platform, ensuring correct cross-compilation. [[1]](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721L30-R49) [[2]](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721L60-R82) [[3]](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721L89-R108)
* Modified artifact naming and packaging to include the architecture in the filenames (e.g., `fpt-linux-arm64-...`), and updated upload steps to match the new naming convention. [[1]](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721L30-R49) [[2]](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721L60-R82) [[3]](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721L89-R108)

**Release artifact handling:**

* Updated the release job to download and include artifacts for both `amd64` and `arm64` architectures for all platforms.